### PR TITLE
Fix pass api key

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -4,7 +4,7 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
-    branches: ["update-dotenv"]
+    branches: ["main"]
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -4,7 +4,7 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
-    branches: ["main"]
+    branches: ["update-dotenv"]
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -4,7 +4,7 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
-    branches: ["update-dotenv"]
+    branches: ["fix-pass-api-key"]
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:

--- a/data_validation.py
+++ b/data_validation.py
@@ -9,7 +9,7 @@ from tiled.client import from_profile
 @task(retries=2, retry_delay_seconds=10)
 def read_all_streams(uid, beamline_acronym):
     logger = get_run_logger()
-    with open("/srv/env.secrets", "r") as secrets:
+    with open("/srv/env.secret", "r") as secrets:
         load_dotenv(stream=secrets)
     api_key = os.environ["TILED_API_KEY"]
     logger.info(f"first 4 characters of key: {api_key[:4]}")

--- a/data_validation.py
+++ b/data_validation.py
@@ -2,15 +2,17 @@ from prefect import task, flow, get_run_logger
 import time as ttime
 from tiled.client import from_uri
 
+@task
+def get_run(uid, api_key=None):
+    cl = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)
+    run = cl["tst/raw"][uid]
+    return run
+
 
 @task(retries=2, retry_delay_seconds=10)
-def read_all_streams(uid, beamline_acronym, api_key=None, dry_run=False):
+def read_all_streams(uid, beamline_acronym, api_key=None):
     logger = get_run_logger()
-    if dry_run:
-        logger.info("Dry run: not creating tiled client or checking streams")
-        return
-    cl = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)
-    run = cl["tst"]["raw"][uid]
+    run = get_run(uid, api_key=api_key)
     logger.info(f"Validating uid {run.start['uid']}")
     start_time = ttime.monotonic()
     for stream in run:
@@ -26,4 +28,4 @@ def read_all_streams(uid, beamline_acronym, api_key=None, dry_run=False):
 
 @flow
 def data_validation(uid, api_key=None, dry_run=False):
-    read_all_streams(uid, beamline_acronym="tst", api_key=api_key, dry_run=dry_run)
+    read_all_streams(uid, beamline_acronym="tst", api_key=api_key)

--- a/data_validation.py
+++ b/data_validation.py
@@ -1,5 +1,7 @@
+import os
+
+from dotenv import load_dotenv
 from prefect import task, flow, get_run_logger
-from prefect.blocks.system import Secret
 import time as ttime
 from tiled.client import from_profile
 
@@ -7,7 +9,10 @@ from tiled.client import from_profile
 @task(retries=2, retry_delay_seconds=10)
 def read_all_streams(uid, beamline_acronym):
     logger = get_run_logger()
-    api_key = Secret.load("tiled-tst-api-key").get()
+    with open("/srv/env.secrets", "r") as secrets:
+        load_dotenv(stream=secrets)
+    api_key = os.environ["TILED_API_KEY"]
+    logger.info(f"first 4 characters of key: {api_key[:4]}")
     cl = from_profile("nsls2", api_key=api_key)
     run = cl["tst"]["raw"][uid]
     logger.info(f"Validating uid {run.start['uid']}")

--- a/data_validation.py
+++ b/data_validation.py
@@ -12,7 +12,6 @@ def read_all_streams(uid, beamline_acronym):
     with open("/srv/tiled.secret", "r") as secrets:
         load_dotenv(stream=secrets)
     api_key = os.environ["TILED_API_KEY"]
-    logger.info(f"first 4 characters of key: {api_key[:4]}")
     cl = from_profile("nsls2", api_key=api_key)
     run = cl["tst"]["raw"][uid]
     logger.info(f"Validating uid {run.start['uid']}")

--- a/data_validation.py
+++ b/data_validation.py
@@ -10,8 +10,13 @@ def get_run(uid, api_key=None):
     return run
 
 
+@task
+def read_stream(run, stream):
+    return run[stream].read()
+
+
 @task(retries=2, retry_delay_seconds=10)
-def read_all_streams(uid, beamline_acronym, api_key=None):
+def read_all_streams(uid, api_key=None):
     logger = get_run_logger()
     run = get_run(uid, api_key=api_key)
     logger.info(f"Validating uid {run.start['uid']}")
@@ -19,7 +24,7 @@ def read_all_streams(uid, beamline_acronym, api_key=None):
     for stream in run:
         logger.info(f"{stream}:")
         stream_start_time = ttime.monotonic()
-        stream_data = run[stream].read()
+        stream_data = read_stream(run, stream)
         stream_elapsed_time = ttime.monotonic() - stream_start_time
         logger.info(f"{stream} elapsed_time = {stream_elapsed_time}")
         logger.info(f"{stream} nbytes = {stream_data.nbytes:_}")
@@ -29,4 +34,4 @@ def read_all_streams(uid, beamline_acronym, api_key=None):
 
 @flow
 def data_validation(uid, api_key=None, dry_run=False):
-    read_all_streams(uid, beamline_acronym="tst", api_key=api_key)
+    read_all_streams(uid, api_key=api_key)

--- a/data_validation.py
+++ b/data_validation.py
@@ -2,6 +2,7 @@ from prefect import task, flow, get_run_logger
 import time as ttime
 from tiled.client import from_uri
 
+
 @task
 def get_run(uid, api_key=None):
     cl = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)

--- a/data_validation.py
+++ b/data_validation.py
@@ -1,7 +1,15 @@
+import os
 from prefect import task, flow, get_run_logger
 import time as ttime
 from tiled.client import from_uri
-from end_of_run_workflow import get_api_key_from_env
+from dotenv import load_dotenv
+
+
+def get_api_key_from_env(api_key=None):
+    with open("/srv/container.secret", "r") as secrets:
+        load_dotenv(stream=secrets)
+    api_key = os.environ["TILED_API_KEY"]
+    return api_key
 
 
 @task

--- a/data_validation.py
+++ b/data_validation.py
@@ -4,8 +4,11 @@ from tiled.client import from_uri
 
 
 @task(retries=2, retry_delay_seconds=10)
-def read_all_streams(uid, beamline_acronym, api_key=None):
+def read_all_streams(uid, beamline_acronym, api_key=None, dry_run=False):
     logger = get_run_logger()
+    if dry_run:
+        logger.info("Dry run: not creating tiled client or checking streams")
+        return
     cl = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)
     run = cl["tst"]["raw"][uid]
     logger.info(f"Validating uid {run.start['uid']}")
@@ -22,5 +25,5 @@ def read_all_streams(uid, beamline_acronym, api_key=None):
 
 
 @flow
-def data_validation(uid, api_key=None):
-    read_all_streams(uid, beamline_acronym="tst", api_key=api_key)
+def data_validation(uid, api_key=None, dry_run=False):
+    read_all_streams(uid, beamline_acronym="tst", api_key=api_key, dry_run=dry_run)

--- a/data_validation.py
+++ b/data_validation.py
@@ -9,7 +9,7 @@ from tiled.client import from_profile
 @task(retries=2, retry_delay_seconds=10)
 def read_all_streams(uid, beamline_acronym):
     logger = get_run_logger()
-    with open("/srv/env.secret", "r") as secrets:
+    with open("/srv/tiled.secret", "r") as secrets:
         load_dotenv(stream=secrets)
     api_key = os.environ["TILED_API_KEY"]
     logger.info(f"first 4 characters of key: {api_key[:4]}")

--- a/data_validation.py
+++ b/data_validation.py
@@ -1,12 +1,12 @@
 from prefect import task, flow, get_run_logger
 import time as ttime
-from tiled.client import from_profile
+from tiled.client import from_uri
 
 
 @task(retries=2, retry_delay_seconds=10)
 def read_all_streams(uid, beamline_acronym, api_key=None):
     logger = get_run_logger()
-    cl = from_profile("nsls2", api_key=api_key)
+    cl = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)
     run = cl["tst"]["raw"][uid]
     logger.info(f"Validating uid {run.start['uid']}")
     start_time = ttime.monotonic()

--- a/data_validation.py
+++ b/data_validation.py
@@ -1,10 +1,13 @@
 from prefect import task, flow, get_run_logger
 import time as ttime
 from tiled.client import from_uri
+from end_of_run_workflow import get_api_key_from_env
 
 
 @task
 def get_run(uid, api_key=None):
+    if not api_key:
+        api_key = get_api_key_from_env()
     cl = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)
     run = cl["tst/raw"][uid]
     return run

--- a/data_validation.py
+++ b/data_validation.py
@@ -1,17 +1,11 @@
-import os
-
-from dotenv import load_dotenv
 from prefect import task, flow, get_run_logger
 import time as ttime
 from tiled.client import from_profile
 
 
 @task(retries=2, retry_delay_seconds=10)
-def read_all_streams(uid, beamline_acronym):
+def read_all_streams(uid, beamline_acronym, api_key=None):
     logger = get_run_logger()
-    with open("/srv/tiled.secret", "r") as secrets:
-        load_dotenv(stream=secrets)
-    api_key = os.environ["TILED_API_KEY"]
     cl = from_profile("nsls2", api_key=api_key)
     run = cl["tst"]["raw"][uid]
     logger.info(f"Validating uid {run.start['uid']}")
@@ -28,5 +22,5 @@ def read_all_streams(uid, beamline_acronym):
 
 
 @flow
-def data_validation(uid):
-    read_all_streams(uid, beamline_acronym="tst")
+def data_validation(uid, api_key=None):
+    read_all_streams(uid, beamline_acronym="tst", api_key=api_key)

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -25,10 +25,11 @@ def log_completion(dry_run=False):
 
 
 @flow
-def end_of_run_workflow(stop_doc, dry_run=False):
+def end_of_run_workflow(stop_doc, api_key=None, dry_run=False):
     uid = stop_doc["run_start"]
     # hello_world()
-    api_key = get_api_key_from_env(api_key=None)
+    if not api_key:
+        api_key = get_api_key_from_env(api_key=None)
     data_validation(uid, return_state=True, api_key=api_key, dry_run=dry_run)
     get_other_docs(uid, api_key=api_key, dry_run=dry_run)
     # long_flow(iterations=100, sleep_length=10, dry_run=dry_run)

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -8,13 +8,9 @@ from dotenv import load_dotenv
 
 
 def get_api_key_from_env(api_key=None):
-    logger = get_run_logger()
-    try:
-        with open("/srv/container.secret", "r") as secrets:
-            load_dotenv(stream=secrets)
-        api_key = os.environ["TILED_API_KEY"]
-    except Exception:
-        logger.exception("Exception while getting Tiled API key")
+    with open("/srv/container.secret", "r") as secrets:
+        load_dotenv(stream=secrets)
+    api_key = os.environ["TILED_API_KEY"]
     return api_key
 
 
@@ -30,7 +26,7 @@ def end_of_run_workflow(stop_doc, api_key=None, dry_run=False):
     # hello_world()
     if not api_key:
         api_key = get_api_key_from_env(api_key=None)
-    data_validation(uid, return_state=True, api_key=api_key, dry_run=dry_run)
-    get_other_docs(uid, api_key=api_key, dry_run=dry_run)
+    data_validation(uid, return_state=True, api_key=api_key)
+    get_other_docs(uid, api_key=api_key)
     # long_flow(iterations=100, sleep_length=10, dry_run=dry_run)
     log_completion(dry_run=dry_run)

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -1,7 +1,21 @@
+import os
+
 from prefect import task, flow, get_run_logger
 from data_validation import data_validation
 from test_extra_client import get_other_docs
+from dotenv import load_dotenv
 # from long_flow import long_flow
+
+
+def get_api_key_from_env(api_key=None):
+    logger = get_run_logger()
+    try:
+        with open("/srv/tiled.secret", "r") as secrets:
+            load_dotenv(stream=secrets)
+        api_key = os.environ["TILED_API_KEY"]
+    except Exception:
+        logger.exception("Exception while getting Tiled API key")
+    return api_key
 
 
 @task
@@ -14,7 +28,8 @@ def log_completion():
 def end_of_run_workflow(stop_doc):
     uid = stop_doc["run_start"]
     # hello_world()
-    data_validation(uid, return_state=True)
-    get_other_docs(uid)
+    api_key = get_api_key_from_env(api_key=None)
+    data_validation(uid, return_state=True, api_key=api_key)
+    get_other_docs(uid, api_key=api_key)
     # long_flow(iterations=100, sleep_length=10)
     log_completion()

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 def get_api_key_from_env(api_key=None):
     logger = get_run_logger()
     try:
-        with open("/srv/tiled.secret", "r") as secrets:
+        with open("/srv/container.secret", "r") as secrets:
             load_dotenv(stream=secrets)
         api_key = os.environ["TILED_API_KEY"]
     except Exception:

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -24,8 +24,6 @@ def log_completion(dry_run=False):
 def end_of_run_workflow(stop_doc, api_key=None, dry_run=False):
     uid = stop_doc["run_start"]
     # hello_world()
-    if not api_key:
-        api_key = get_api_key_from_env(api_key=None)
     data_validation(uid, return_state=True, api_key=api_key)
     get_other_docs(uid, api_key=api_key)
     # long_flow(iterations=100, sleep_length=10, dry_run=dry_run)

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -3,15 +3,7 @@ import os
 from prefect import task, flow, get_run_logger
 from data_validation import data_validation
 from test_extra_client import get_other_docs
-from dotenv import load_dotenv
 # from long_flow import long_flow
-
-
-def get_api_key_from_env(api_key=None):
-    with open("/srv/container.secret", "r") as secrets:
-        load_dotenv(stream=secrets)
-    api_key = os.environ["TILED_API_KEY"]
-    return api_key
 
 
 @task

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -19,17 +19,17 @@ def get_api_key_from_env(api_key=None):
 
 
 @task
-def log_completion():
+def log_completion(dry_run=False):
     logger = get_run_logger()
-    logger.info("Complete")
+    logger.info(f"Complete! Dry run = {dry_run}")
 
 
 @flow
-def end_of_run_workflow(stop_doc):
+def end_of_run_workflow(stop_doc, dry_run=False):
     uid = stop_doc["run_start"]
     # hello_world()
     api_key = get_api_key_from_env(api_key=None)
-    data_validation(uid, return_state=True, api_key=api_key)
-    get_other_docs(uid, api_key=api_key)
-    # long_flow(iterations=100, sleep_length=10)
-    log_completion()
+    data_validation(uid, return_state=True, api_key=api_key, dry_run=dry_run)
+    get_other_docs(uid, api_key=api_key, dry_run=dry_run)
+    # long_flow(iterations=100, sleep_length=10, dry_run=dry_run)
+    log_completion(dry_run=dry_run)

--- a/long_flow.py
+++ b/long_flow.py
@@ -1,9 +1,10 @@
-from prefect import task, flow
+from prefect import task, flow, get_run_logger
 import time as ttime
 
 
 @task
 def print_and_sleep(iterations, sleep_length, dry_run=False):
+    logger = get_run_logger()
     # Long running task
     print("Long task...")
     if dry_run:

--- a/long_flow.py
+++ b/long_flow.py
@@ -3,16 +3,19 @@ import time as ttime
 
 
 @task
-def print_and_sleep(iterations, sleep_length):
+def print_and_sleep(iterations, sleep_length, dry_run=False):
     # Long running task
     print("Long task...")
+    if dry_run:
+        logger.info("Dry run: skipping long task")
+        return
     for i in range(int(iterations)):
         print(f"Iteration number {i}")
         ttime.sleep(int(sleep_length))
 
 
 @flow(log_prints=True)
-def long_flow(iterations, sleep_length):
+def long_flow(iterations, sleep_length, dry_run=False):
     print("Starting long flow...")
-    print_and_sleep(iterations, sleep_length)
+    print_and_sleep(iterations, sleep_length, dry_run=dry_run)
     print("Done!")

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,6 +8,7 @@ prefect = "3.*"
 python = "<3.14"
 tiled-client = ">=0.2.3"
 bluesky-tiled-plugins = ">=2"
+python-dotenv = ">=1.2.1,<2"
 
 [pypi-dependencies]
 lixtools = "==2023.1.23.0"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -10,7 +10,7 @@ pull:
       directory: /repo
   - prefect.deployments.steps.git_clone:
       repository: https://github.com/nsls2/tst-workflows.git
-      branch: update-dotenv
+      branch: main
 
 deployments:
   - name: tst-end-of-run-workflow-docker
@@ -26,7 +26,7 @@ deployments:
       job_variables:
         env:
           TILED_SITE_PROFILES: /nsls2/software/etc/tiled/profiles
-        image: ghcr.io/nsls2/tst-workflows:update-dotenv
+        image: ghcr.io/nsls2/tst-workflows:main
         image_pull_policy: Always
         network_mode: slirp4netns
         userns: "keep-id:uid=402974,gid=402974" # workflow-tst:workflow-tst

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -14,7 +14,7 @@ pull:
 
 deployments:
   - name: tst-end-of-run-workflow-docker
-    version: 0.1.2
+    version: 0.1.3
     tags:
       - tst
       - main

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -9,8 +9,8 @@ pull:
   - prefect.deployments.steps.set_working_directory:
       directory: /repo
   - prefect.deployments.steps.git_clone:
-      repository: https://github.com/nsls2/tst-workflows.git
-      branch: main
+      repository: https://github.com/junaishima/tst-workflows.git
+      branch: update-dotenv
 
 deployments:
   - name: tst-end-of-run-workflow-docker
@@ -24,7 +24,7 @@ deployments:
     schedule: {}
     work_pool:
       job_variables:
-        image: ghcr.io/nsls2/tst-workflows:main
+        image: ghcr.io/junaishima/tst-workflows:update-dotenv
         image_pull_policy: Always
         network_mode: slirp4netns
         userns: "keep-id:uid=402974,gid=402974" # workflow-tst:workflow-tst

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -10,7 +10,7 @@ pull:
       directory: /repo
   - prefect.deployments.steps.git_clone:
       repository: https://github.com/junaishima/tst-workflows.git
-      branch: update-dotenv
+      branch: fix-pass-api-key
 
 deployments:
   - name: tst-end-of-run-workflow-docker
@@ -24,7 +24,7 @@ deployments:
     schedule: {}
     work_pool:
       job_variables:
-        image: ghcr.io/junaishima/tst-workflows:update-dotenv
+        image: ghcr.io/junaishima/tst-workflows:fix-pass-api-key
         image_pull_policy: Always
         network_mode: slirp4netns
         userns: "keep-id:uid=402974,gid=402974" # workflow-tst:workflow-tst

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -33,6 +33,6 @@ deployments:
         volumes:
           - /nsls2/data/tst/proposals:/nsls2/data/tst/proposals
           - /nsls2/software/etc/tiled:/nsls2/software/etc/tiled
-          - /srv/prefect3-docker-worker-tst/tiled:/srv
+          - /srv/prefect3-docker-worker-tst/app:/srv
         auto_remove: true
       name: tst-work-pool-docker

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -24,15 +24,12 @@ deployments:
     schedule: {}
     work_pool:
       job_variables:
-        env:
-          TILED_SITE_PROFILES: /nsls2/software/etc/tiled/profiles
         image: ghcr.io/nsls2/tst-workflows:main
         image_pull_policy: Always
         network_mode: slirp4netns
         userns: "keep-id:uid=402974,gid=402974" # workflow-tst:workflow-tst
         volumes:
           - /nsls2/data/tst/proposals:/nsls2/data/tst/proposals
-          - /nsls2/software/etc/tiled:/nsls2/software/etc/tiled
           - /srv/prefect3-docker-worker-tst/app:/srv
         auto_remove: true
       name: tst-work-pool-docker

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -33,5 +33,6 @@ deployments:
         volumes:
           - /nsls2/data/tst/proposals:/nsls2/data/tst/proposals
           - /nsls2/software/etc/tiled:/nsls2/software/etc/tiled
+          - /srv/prefect3-docker-worker-tst/env.secret:/srv/env.secret
         auto_remove: true
       name: tst-work-pool-docker

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -33,6 +33,6 @@ deployments:
         volumes:
           - /nsls2/data/tst/proposals:/nsls2/data/tst/proposals
           - /nsls2/software/etc/tiled:/nsls2/software/etc/tiled
-          - /srv/prefect3-docker-worker-tst:/srv
+          - /srv/prefect3-docker-worker-tst/tiled:/srv
         auto_remove: true
       name: tst-work-pool-docker

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -10,7 +10,7 @@ pull:
       directory: /repo
   - prefect.deployments.steps.git_clone:
       repository: https://github.com/nsls2/tst-workflows.git
-      branch: main
+      branch: update-dotenv
 
 deployments:
   - name: tst-end-of-run-workflow-docker
@@ -26,7 +26,7 @@ deployments:
       job_variables:
         env:
           TILED_SITE_PROFILES: /nsls2/software/etc/tiled/profiles
-        image: ghcr.io/nsls2/tst-workflows:main
+        image: ghcr.io/nsls2/tst-workflows:update-dotenv
         image_pull_policy: Always
         network_mode: slirp4netns
         userns: "keep-id:uid=402974,gid=402974" # workflow-tst:workflow-tst

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -14,7 +14,7 @@ pull:
 
 deployments:
   - name: tst-end-of-run-workflow-docker
-    version: 0.1.1
+    version: 0.1.2
     tags:
       - tst
       - main

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -33,6 +33,6 @@ deployments:
         volumes:
           - /nsls2/data/tst/proposals:/nsls2/data/tst/proposals
           - /nsls2/software/etc/tiled:/nsls2/software/etc/tiled
-          - /srv/prefect3-docker-worker-tst/env.secret:/srv/env.secret
+          - /srv/prefect3-docker-worker-tst:/srv
         auto_remove: true
       name: tst-work-pool-docker

--- a/test_extra_client.py
+++ b/test_extra_client.py
@@ -3,7 +3,7 @@ from utils import get_tiled_client
 
 
 @task
-def get_other_docs(uid):
+def get_other_docs(uid, api_key=api_key):
     logger = get_run_logger()
     result = get_tiled_client()["raw"][uid]
     for name, doc in result.documents():

--- a/test_extra_client.py
+++ b/test_extra_client.py
@@ -3,7 +3,7 @@ from utils import get_tiled_client
 
 
 @task
-def get_other_docs(uid, api_key=api_key):
+def get_other_docs(uid, api_key=None):
     logger = get_run_logger()
     result = get_tiled_client()["raw"][uid]
     for name, doc in result.documents():

--- a/test_extra_client.py
+++ b/test_extra_client.py
@@ -1,13 +1,10 @@
 from prefect import task, get_run_logger
-from utils import get_tiled_client
+from data_validation import get_run
 
 
 @task
-def get_other_docs(uid, api_key=None, dry_run=False):
+def get_other_docs(uid, api_key=None):
     logger = get_run_logger()
-    if dry_run:
-        logger.info("Dry run: not getting other docs")
-        return
-    result = get_tiled_client()["raw"][uid]
+    result = get_run(uid, api_key=api_key)
     for name, doc in result.documents():
         logger.info(f"name: {name}, doc: {doc}")

--- a/test_extra_client.py
+++ b/test_extra_client.py
@@ -6,7 +6,7 @@ from utils import get_tiled_client
 def get_other_docs(uid, api_key=None, dry_run=False):
     logger = get_run_logger()
     if dry_run:
-        logger.info(f"Dry run: not getting other docs")
+        logger.info("Dry run: not getting other docs")
         return
     result = get_tiled_client()["raw"][uid]
     for name, doc in result.documents():

--- a/test_extra_client.py
+++ b/test_extra_client.py
@@ -3,8 +3,11 @@ from utils import get_tiled_client
 
 
 @task
-def get_other_docs(uid, api_key=None):
+def get_other_docs(uid, api_key=None, dry_run=False):
     logger = get_run_logger()
+    if dry_run:
+        logger.info(f"Dry run: not getting other docs")
+        return
     result = get_tiled_client()["raw"][uid]
     for name, doc in result.documents():
         logger.info(f"name: {name}, doc: {doc}")

--- a/utils.py
+++ b/utils.py
@@ -9,7 +9,7 @@ LOCATION = "tst"
 
 def get_tiled_client():
     logger = get_run_logger()
-    with open("/srv/env.secrets", "r") as secrets:
+    with open("/srv/env.secret", "r") as secrets:
         load_dotenv(stream=secrets)
     api_key = os.environ["TILED_API_KEY"]
     logger.info(f"first 4 characters of key: {api_key:4}")

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,0 @@
-from tiled.client import from_uri
-
-
-LOCATION = "tst"
-
-
-def get_tiled_client(api_key=None):
-    tiled_client = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)[LOCATION]
-    return tiled_client

--- a/utils.py
+++ b/utils.py
@@ -9,7 +9,7 @@ LOCATION = "tst"
 
 def get_tiled_client():
     logger = get_run_logger()
-    with open("/srv/env.secret", "r") as secrets:
+    with open("/srv/tiled.secret", "r") as secrets:
         load_dotenv(stream=secrets)
     api_key = os.environ["TILED_API_KEY"]
     logger.info(f"first 4 characters of key: {api_key:4}")

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,5 @@
 from tiled.client import from_profile
 
-import os
 
 LOCATION = "tst"
 

--- a/utils.py
+++ b/utils.py
@@ -12,6 +12,5 @@ def get_tiled_client():
     with open("/srv/tiled.secret", "r") as secrets:
         load_dotenv(stream=secrets)
     api_key = os.environ["TILED_API_KEY"]
-    logger.info(f"first 4 characters of key: {api_key:4}")
     tiled_client = from_profile("nsls2", api_key=api_key)[LOCATION]
     return tiled_client

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,4 @@
 from dotenv import load_dotenv
-from prefect import get_run_logger
 from tiled.client import from_profile
 
 import os
@@ -8,7 +7,6 @@ LOCATION = "tst"
 
 
 def get_tiled_client():
-    logger = get_run_logger()
     with open("/srv/tiled.secret", "r") as secrets:
         load_dotenv(stream=secrets)
     api_key = os.environ["TILED_API_KEY"]

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
+from dotenv import load_dotenv
+from prefect import get_run_logger
 from tiled.client import from_profile
-from prefect.blocks.system import Secret
 
 import os
 
@@ -7,7 +8,10 @@ LOCATION = "tst"
 
 
 def get_tiled_client():
-    os.environ["TILED_API_KEY"] = Secret.load(f"tiled-{LOCATION}-api-key").get()
-    tiled_client = from_profile("nsls2")[LOCATION]
-    os.environ.pop("TILED_API_KEY")
+    logger = get_run_logger()
+    with open("/srv/env.secrets", "r") as secrets:
+        load_dotenv(stream=secrets)
+    api_key = os.environ["TILED_API_KEY"]
+    logger.info(f"first 4 characters of key: {api_key:4}")
+    tiled_client = from_profile("nsls2", api_key=api_key)[LOCATION]
     return tiled_client

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,3 @@
-from dotenv import load_dotenv
 from tiled.client import from_profile
 
 import os
@@ -6,9 +5,6 @@ import os
 LOCATION = "tst"
 
 
-def get_tiled_client():
-    with open("/srv/tiled.secret", "r") as secrets:
-        load_dotenv(stream=secrets)
-    api_key = os.environ["TILED_API_KEY"]
+def get_tiled_client(api_key=None):
     tiled_client = from_profile("nsls2", api_key=api_key)[LOCATION]
     return tiled_client

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,9 @@
-from tiled.client import from_profile
+from tiled.client import from_uri
 
 
 LOCATION = "tst"
 
 
 def get_tiled_client(api_key=None):
-    tiled_client = from_profile("nsls2", api_key=api_key)[LOCATION]
+    tiled_client = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)[LOCATION]
     return tiled_client


### PR DESCRIPTION
I noticed yesterday that the Tiled API key which is passed around the functions is visible on Prefect Cloud when the workflow is run in production.

This fix will ensure the Tiled API key is only read from the environment file right where it is used so that it is not passed around.

The Tiled API key used in the `end_of_run_workflow()` function is currently only used when testing, either CI or local interactive testing. In these cases, Prefect Cloud will not store the parameters used to call the functions, so the API key will never get exposed.

Note that this PR also includes the dotenv change.